### PR TITLE
Doxygen

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Additionally, there is a function to remove the encoding information, which is n
 
 Currently, er assumes the group of processes participating is the same as MPI_COMM_WORLD.
 
-Usage is documented in [src/er.h](src/er.h).
+Usage is documented in [src/er.h](src/er.h) and in the [user API](https://ecp-veloc.github.io/component-user-docs/group__er.html) docs.
 
 # Building
 

--- a/src/er.h
+++ b/src/er.h
@@ -3,6 +3,19 @@
 
 #include "mpi.h"
 
+/** \defgroup er ER
+ *  \brief Encode and Rebuild
+ *
+ * ER is the abstraction of shuffile and redset into a single
+ * interface, SCR and VeloC use both and er to simplify the rebuilding
+ * steps. On a restart, shuffile is used to first move files back to
+ * owning ranks, depending on new rank-to-node mapping. Then redset is
+ * used to rebuild missing files after the shuffle. */
+
+/** \file er.h
+ *  \ingroup er
+ *  \brief encoding and redundancy library */
+
 /* enable C++ codes to include this header directly */
 #ifdef __cplusplus
 extern "C" {
@@ -16,55 +29,55 @@ extern "C" {
 #define ER_DIRECTION_REMOVE  (3)
 
 int ER_Init(
-  const char* conf_file /* IN - path to configuration file (can be NULL for default) */
+  const char* conf_file /**< [IN] - path to configuration file (can be NULL for default) */
 );
 
 int ER_Finalize();
 
-/* defines a redundancy scheme, returns scheme id as integer */
+/** defines a redundancy scheme, returns scheme id as integer */
 int ER_Create_Scheme(
-  MPI_Comm comm,              /* IN - communicator of processes participating in scheme */
-  const char* failure_domain, /* IN - processes with same value of failure_domain are assumed to fail at the same time */
-  int data_blocks,            /* IN - number of original data blocks */
-  int erasure_blocks          /* IN - number of erasure blocks to be generated */
+  MPI_Comm comm,              /**< [IN] - communicator of processes participating in scheme */
+  const char* failure_domain, /**< [IN] - processes with same value of failure_domain are assumed to fail at the same time */
+  int data_blocks,            /**< [IN] - number of original data blocks */
+  int erasure_blocks          /**< [IN] - number of erasure blocks to be generated */
 );
 
 int ER_Free_Scheme(
-  int scheme_id /* IN - release resources associated with specified scheme id */
+  int scheme_id /**< [IN] - release resources associated with specified scheme id */
 );
 
-/* create a named set, and specify whether it should be encoded, recovered, or unencoded */
+/** create a named set, and specify whether it should be encoded, recovered, or unencoded */
 int ER_Create(
-  MPI_Comm comm_world, /* IN - communicator of processes participating in operation */
-  MPI_Comm comm_store, /* IN - communicator of processes that share access to storage holding files */
-  const char* name,    /* IN - name of operation */
-  int direction,       /* IN - operation to execute: one of ER_DIRECTION constants */
-  int scheme_id        /* IN - redundancy scheme to be applied to this set */
+  MPI_Comm comm_world, /**< [IN] - communicator of processes participating in operation */
+  MPI_Comm comm_store, /**< [IN] - communicator of processes that share access to storage holding files */
+  const char* name,    /**< [IN] - name of operation */
+  int direction,       /**< [IN] - operation to execute: one of ER_DIRECTION constants */
+  int scheme_id        /**< [IN] - redundancy scheme to be applied to this set */
 );
 
-/* adds file to specified set id */
+/** adds file to specified set id */
 int ER_Add(
-  int set_id,      /* IN - set id to add file to */
-  const char* file /* IN - path to file */
+  int set_id,      /**< [IN] - set id to add file to */
+  const char* file /**< [IN] - path to file */
 );
 
-/* initiate encode/rebuild operation on specified set id */
+/** initiate encode/rebuild operation on specified set id */
 int ER_Dispatch(
-  int set_id           /* IN - set id to dispatch */
+  int set_id           /**< [IN] - set id to dispatch */
 );
 
-/* tests whether ongoing dispatch operation to finish,
+/** tests whether ongoing dispatch operation to finish,
  * returns 1 if done, 0 otherwise */
 int ER_Test(
   int set_id
 );
 
-/* wait for ongoing dispatch operation to finish */
+/** wait for ongoing dispatch operation to finish */
 int ER_Wait(
   int set_id
 );
 
-/* free internal resources associated with set id */
+/** free internal resources associated with set id */
 int ER_Free(
   int set_id
 );

--- a/src/er_util.h
+++ b/src/er_util.h
@@ -4,6 +4,10 @@
 #include "mpi.h"
 #include "kvtree.h"
 
+/** \file er_util.h
+ *  \ingroup er
+ *  \brief er utilities */
+
 #define ER_FAILURE (1)
 
 #define ER_MAX_FILENAME (1024)
@@ -14,33 +18,33 @@ extern char* er_hostname;
 extern int er_mpi_buf_size;
 extern size_t er_page_size;
 
-/* print error message to stdout */
+/** print error message to stdout */
 void er_err(const char *fmt, ...);
 
-/* print warning message to stdout */
+/** print warning message to stdout */
 void er_warn(const char *fmt, ...);
 
-/* print message to stdout if er_debug is set and it is >= level */
+/** print message to stdout if er_debug is set and it is >= level */
 void er_dbg(int level, const char *fmt, ...);
 
-/* print abort message and kill run */
+/** print abort message and kill run */
 void er_abort(int rc, const char *fmt, ...);
 
-/* allocate size bytes, returns NULL if size == 0,
+/** allocate size bytes, returns NULL if size == 0,
  * calls er_abort if allocation fails */
 #define ER_MALLOC(X) er_malloc(X, __FILE__, __LINE__);
 void* er_malloc(size_t size, const char* file, int line);
 
-/* pass address of pointer to be freed, frees memory if not NULL and sets pointer to NULL */
+/** pass address of pointer to be freed, frees memory if not NULL and sets pointer to NULL */
 void er_free(void* ptr);
 
-/* allocates a block of memory and aligns it to specified alignment */
+/** allocates a block of memory and aligns it to specified alignment */
 void* er_align_malloc(size_t size, size_t align);
 
-/* frees a blocked allocated with a call to er_align_malloc */
+/** frees a blocked allocated with a call to er_align_malloc */
 void er_align_free(void* buf);
 
-/* sends a NUL-terminated string to a process,
+/** sends a NUL-terminated string to a process,
  * allocates space and recieves a NUL-terminated string from a process,
  * can specify MPI_PROC_NULL as either send or recv rank */
 int er_str_sendrecv(
@@ -49,7 +53,7 @@ int er_str_sendrecv(
   MPI_Comm comm
 );
 
-/* returns true (non-zero) if flag on each process in comm is true */
+/** returns true (non-zero) if flag on each process in comm is true */
 int er_alltrue(int flag, MPI_Comm comm);
 
 #endif


### PR DESCRIPTION
Re-formatted the comments in the `.h` files to allow doxygen parsing for [generated documentation](https://ecp-veloc.github.io/component-user-docs/).