### PR TITLE
support multiple replicas in partner scheme

### DIFF
--- a/src/er.c
+++ b/src/er.c
@@ -461,15 +461,16 @@ int ER_Create_Scheme(
   if (erasure_blocks == 0) {
     /* SINGLE */
     redset_rc = redset_create_single(comm, failure_domain, d);
-  } else if (data_blocks == erasure_blocks) {
-    /* PARTNER */
-    redset_rc = redset_create_partner(comm, failure_domain, er_set_size, 1, d);
   } else if (erasure_blocks == 1) {
     /* XOR */
     redset_rc = redset_create_xor(comm, failure_domain, er_set_size, d);
   } else if (erasure_blocks < data_blocks) {
     /* Reed-Solomon */
     redset_rc = redset_create_rs(comm, failure_domain, er_set_size, erasure_blocks, d);
+  } else if (erasure_blocks % data_blocks == 0) {
+    /* PARTNER */
+    int replicas = erasure_blocks / data_blocks;
+    redset_rc = redset_create_partner(comm, failure_domain, er_set_size, replicas, d);
   } else {
     /* some form of Reed-Solomon that we don't support yet */
     er_free(&d);


### PR DESCRIPTION
Support redset partner replicas in ``ER_Create_Scheme`` when ``erasure_blocks`` is evenly divisible by ``data_blocks``, i.e., ``(erasure_blocks / data_blocks) = k`` implies ``k`` replicas via redset partner scheme.