### PR TITLE
Incremental release v0.0.4

### DIFF
--- a/src/er.h
+++ b/src/er.h
@@ -24,6 +24,8 @@ extern "C" {
 #define ER_SUCCESS (0)
 #define ER_FAILURE (1)
 
+#define ER_VERSION "0.0.4"
+
 #define ER_DIRECTION_ENCODE  (1)
 #define ER_DIRECTION_REBUILD (2)
 #define ER_DIRECTION_REMOVE  (3)

--- a/src/er_util.c
+++ b/src/er_util.c
@@ -24,8 +24,6 @@
 #include "er.h"
 #include "er_util.h"
 
-#define ER_VERSION "1.0"
-
 int er_debug = 1;
 
 int er_rank = -1;


### PR DESCRIPTION
Move `ER_VERSION` to _er.h_ and update to v0.0.4 for tagging a new release.

This is in preparation for SCR 3.0rc1 and 3.0 releases and addresses the second item of #13.