### PR TITLE
increase default buffer size to 1MB

### DIFF
--- a/src/er_util.c
+++ b/src/er_util.c
@@ -26,7 +26,7 @@ int er_debug = 1;
 int er_rank = -1;
 char* er_hostname = NULL;
 
-int er_mpi_buf_size = 131072;
+int er_mpi_buf_size = 1024 * 1024;
 size_t er_page_size;
 
 int er_set_size = 8;


### PR DESCRIPTION
The MPI buffer size is used both to read/write files and to transfer MPI messages between processes.  This raises the default form 128KB to 1MB.  This size should be large enough to saturate MPI bandwidth.