### PR TITLE
restore shuffile file on rebuild

### DIFF
--- a/src/er.c
+++ b/src/er.c
@@ -738,6 +738,44 @@ static int er_rebuild(MPI_Comm comm_world, MPI_Comm comm_store, const char* path
     /* rebuild failed, rc is same value across comm_world */
     rc = ER_FAILURE;
   }
+
+  /* rebuild shuffile file in case we are on a new node */
+
+  /* if the rebuild succeeds, rebuild the shuffile file */
+  if (rc == ER_SUCCESS) {
+    /* get list of app files and files added by redudancy scheme */
+    redset_filelist orig_list = redset_filelist_orig_get(redset_path, d);
+    redset_filelist red_list  = redset_filelist_get(redset_path, d);
+
+    /* allocate space for a new file list to include both app files and redundancy files */
+    int orig_count = redset_filelist_count(orig_list);
+    int red_count  = redset_filelist_count(red_list);
+    int count = orig_count + red_count;
+    const char** filenames2 = (const char**) ER_MALLOC(count * sizeof(char*));
+
+    /* fill in list of file names */
+    int i;
+    for (i = 0; i < orig_count; i++) {
+      /* application files */
+      filenames2[i] = redset_filelist_file(orig_list, i);
+    }
+    for (i = 0; i < red_count; i++) {
+      /* redundancy files */
+      filenames2[orig_count + i] = redset_filelist_file(red_list, i);
+    }
+
+    /* associate list of both app files and redundancy files with calling process */
+    if (shuffile_create(comm_world, comm_store, count, filenames2, shuffile_file) != SHUFFILE_SUCCESS) {
+      /* failed to register files with shuffile */
+      rc = ER_FAILURE;
+    }
+
+    /* free the new file list */
+    er_free(&filenames2);
+    redset_filelist_release(&red_list);
+    redset_filelist_release(&orig_list);
+  }
+
   redset_delete(&d);
 
   /* if successful, update state to ENCODED, otherwise leave as CORRUPT */


### PR DESCRIPTION
This uses a new redset call to rebuild the shuffile file during ``er_rebuild``.

Resolves: https://github.com/ECP-VeloC/er/issues/39